### PR TITLE
vLLM Easier cudagraph integration

### DIFF
--- a/csrc/kernels/get_mla_metadata.cu
+++ b/csrc/kernels/get_mla_metadata.cu
@@ -37,7 +37,7 @@ get_mla_metadata_kernel(__grid_constant__ const Mla_metadata_params params) {
         num_splits_shared[0] = 0;
         for (int i = 0; i < num_sm_parts; ++i) {
             int tile_scheduler_metadata0[4], tile_scheduler_metadata1;
-            tile_scheduler_metadata0[0] = now_idx;
+            tile_scheduler_metadata0[0] = (now_idx >= batch_size ? -1 : now_idx);
             tile_scheduler_metadata0[1] = now_block * block_size_n;
             tile_scheduler_metadata1 = now_n_split_idx;
             int remain_payload = payload;

--- a/csrc/kernels/mla_combine.cu
+++ b/csrc/kernels/mla_combine.cu
@@ -26,7 +26,7 @@ flash_fwd_mla_combine_kernel(__grid_constant__ const Flash_fwd_mla_params params
     const int end_split_idx = __ldg(params.num_splits_ptr + batch_idx + 1);
     const int my_num_splits = end_split_idx - start_split_idx;
     FLASH_DEVICE_ASSERT(my_num_splits <= MAX_SPLITS);
-    if (my_num_splits == 1) {
+    if (my_num_splits <= 1) {
         return;
     }
     

--- a/csrc/kernels/splitkv_mla.cu
+++ b/csrc/kernels/splitkv_mla.cu
@@ -1022,7 +1022,7 @@ flash_fwd_splitkv_mla_kernel(__grid_constant__ const Flash_fwd_mla_params params
     int begin_seqlen = tile_scheduler_metadata.y;
     int end_idx = tile_scheduler_metadata.z;
     int end_seqlen = tile_scheduler_metadata.w;
-    if (begin_idx >= params.b) return;
+    if (begin_idx >= params.b || begin_idx < 0) return;
     int begin_n_split_idx = __ldg(tile_scheduler_metadata_ptr + 4);
 
     // Copy the first Q


### PR DESCRIPTION
This PR makes it easier to get a correct FlashMLA full cudagraph integration in vLLM where padding for cudagraph's happens after attention metadata data building (i.e. `get_mla_metadata`)

The changes
```
tile_scheduler_metadata0[0] = (now_idx >= batch_size ? -1 : now_idx);
```
and
```
if (begin_idx >= params.b || begin_idx < 0) return;
```
allows `get_mla_metadata` to be called with a smaller batch size than the graph was captured with since it now uses `-1` to mark no-work tiles instead of `params.b`



The change
```
if (my_num_splits <= 1) {
```
makes it easier to pad out `num_splits` (cumulative) since we can just do:
```
self.cg_buf_num_splits[n:].fill_(num_splits[-1])
```
which pads with 0 split elements instead of have to pad with 1 split elements which is more complicated:

```
buffer_padding_size = self.cg_buf_num_splits.size(0) - n
self.cg_buf_num_splits[n:] = num_splits[-1] + 1 + torch.arange(buffer_padding_size)
```