### PR TITLE
[Bugfix] Clamp num_sm_parts to >= 1 in dense fp8 decoding metadata

### DIFF
--- a/csrc/extension/sm90/dense_fp8/pybind.cpp
+++ b/csrc/extension/sm90/dense_fp8/pybind.cpp
@@ -206,7 +206,7 @@ get_mla_decoding_metadata_dense_fp8(
     auto options = seqlens_k.options();
     auto dprops = at::cuda::getCurrentDeviceProperties();
     int sm_count = dprops->multiProcessorCount;
-    int num_sm_parts = sm_count / num_heads_k / cutlass::ceil_div(num_heads_per_head_k, block_size_m);
+    int num_sm_parts = std::max(sm_count / num_heads_k / cutlass::ceil_div(num_heads_per_head_k, block_size_m), 1);
     auto tile_scheduler_metadata = torch::empty({num_sm_parts, TileSchedulerMetaDataSize}, options);
     auto num_splits = torch::empty({batch_size + 1}, options);
     int *tile_scheduler_metadata_ptr = tile_scheduler_metadata.data_ptr<int>();


### PR DESCRIPTION
## Problem

`get_mla_decoding_metadata_dense_fp8` (`csrc/extension/sm90/dense_fp8/pybind.cpp`) computes `num_sm_parts` **without** the `std::max(..., 1)` clamp that the regular dense decoding path already applies (`csrc/api/dense_decode.h`):

```cpp
// dense fp8 (buggy)
int num_sm_parts = sm_count / num_heads_k / cutlass::ceil_div(num_heads_per_head_k, block_size_m);

// regular dense (correct)
int num_sm_parts = std::max(arch.num_sms / num_heads_k / cutlass::ceil_div(...), 1);
```

When `ceil_div(num_heads_per_head_k, block_size_m) > sm_count` (with `num_heads_k == 1`), `num_sm_parts` becomes **0**. The metadata kernel (`flash_fwd_mla_metadata.cu`) then:
- computes `payload = ceil_div(total_num_blocks, 0)` — divide-by-zero, and
- never enters its `for (i < num_sm_parts)` loop,

so `now_idx` stays `0 != batch_size` and the device assert fires:

```
Assertion failed (.../flash_fwd_mla_metadata.cu:64): now_idx == batch_size && now_block == 0 && now_n_split_idx == 0
```

This poisons the CUDA context, surfacing downstream as `CUDA_ERROR_LAUNCH_FAILED (unspecified launch failure)`.

## Impact

Breaks MLA + fp8 KV cache in vLLM for any model with enough query heads once a batch reaches the decode pathway with a large enough query length. Concretely, `num_q_tokens_per_head_k = max_query_len * num_q_heads`, and vLLM routes short prompts (query length ≤ 128) through the decode pathway — so **DeepSeek-R1 (128 heads) crashes on any 67–128 token prompt** on a 132-SM GPU (H100/H200). Reported in [vllm-project/vllm#47935](https://github.com/vllm-project/vllm/issues/47935).

## Fix

Clamp `num_sm_parts` to a minimum of 1, matching the regular dense path.

## Testing

On an H200 (132 SMs), before the fix both a direct call to `get_mla_decoding_metadata_dense_fp8` and an end-to-end vLLM run (DeepSeek-V3 architecture, 128 heads, fp8 KV cache, FlashMLA) crashed with the assertion above for a 100-token prompt. After the fix:

- Direct metadata call with `num_q_tokens_per_head_k` = 8449 and 16384 (both previously `num_sm_parts → 0`): returns valid metadata (`num_sm_parts` clamped to 1), no crash.
- End-to-end vLLM generate with 100- and 128-token prompts: completes normally.
- Control (66-token prompt, `num_sm_parts = 1`) unaffected.