### PR TITLE
Make get_cached_device_prop thread-safe; fix head_size_v message

### DIFF
--- a/csrc/api/dense_decode.h
+++ b/csrc/api/dense_decode.h
@@ -58,7 +58,7 @@ dense_attn_decode_interface(
     const int num_heads_q = q.size(2);
     const int head_size_k = q.size(3);
     STD_TORCH_CHECK(head_size_k == 576 || head_size_k == 512, "Only head_size_k == 576 or 512 is supported");
-    STD_TORCH_CHECK(head_size_v == 512, "Only head_size_v == 576 is supported");
+    STD_TORCH_CHECK(head_size_v == 512, "Only head_size_v == 512 is supported");
 
     const int max_num_blocks_per_seq = block_table.size(1);
     const int num_blocks = kcache.size(0);

--- a/csrc/kerutils/include/kerutils/supplemental/device_prop.h
+++ b/csrc/kerutils/include/kerutils/supplemental/device_prop.h
@@ -3,28 +3,54 @@
 #include <cuda_runtime.h>
 
 #include <torch/csrc/stable/accelerator.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <deque>
+#include <mutex>
+#include <vector>
 
 namespace kerutils {
 
 // Cached device properties (SM count, compute capability, ...) for the current
 // device, queried via the CUDA Runtime and cached per device index. ABI-stable
 // replacement for at::cuda::getCurrentDeviceProperties().
-inline const cudaDeviceProp &get_cached_device_prop() {
-    int device_idx = static_cast<int>(torch::stable::accelerator::getCurrentDeviceIndex());
-    constexpr int kMaxDevices = 16;
-    static cudaDeviceProp props[kMaxDevices];
-    static bool inited[kMaxDevices] = {false};
-    if (device_idx < 0 || device_idx >= kMaxDevices) {
-        // Uncached fallback for unexpectedly large device indices.
-        static thread_local cudaDeviceProp tmp;
-        cudaGetDeviceProperties(&tmp, device_idx);
-        return tmp;
-    }
-    if (!inited[device_idx]) {
-        cudaGetDeviceProperties(&props[device_idx], device_idx);
-        inited[device_idx] = true;
-    }
-    return props[device_idx];
+// Thread-safe: this mirrors vLLM's csrc/libtorch_stable/torch_utils.h
+namespace detail {
+
+inline std::deque<std::once_flag> device_flags;
+inline std::vector<cudaDeviceProp> device_properties;
+inline std::once_flag device_vectors_init_flag;
+
+inline void init_device_vectors() {
+    int device_count = 0;
+    cudaError_t err = cudaGetDeviceCount(&device_count);
+    STD_TORCH_CHECK(err == cudaSuccess,
+                    "cudaGetDeviceCount failed: ", cudaGetErrorString(err));
+    device_flags.resize(device_count);
+    device_properties.resize(device_count);
 }
 
+inline void init_device_property(int device_index) {
+    cudaDeviceProp device_prop{};
+    cudaError_t err = cudaGetDeviceProperties(&device_prop, device_index);
+    STD_TORCH_CHECK(err == cudaSuccess,
+                    "cudaGetDeviceProperties failed: ", cudaGetErrorString(err));
+    device_properties[device_index] = device_prop;
 }
+
+}  // namespace detail
+
+inline const cudaDeviceProp &get_cached_device_prop() {
+    std::call_once(detail::device_vectors_init_flag, detail::init_device_vectors);
+    int device_index = static_cast<int>(torch::stable::accelerator::getCurrentDeviceIndex());
+    STD_TORCH_CHECK(
+        device_index >= 0 &&
+            static_cast<size_t>(device_index) < detail::device_properties.size(),
+        "CUDA device index ", device_index, " out of range [0, ",
+        detail::device_properties.size(), ")");
+    std::call_once(detail::device_flags[device_index], detail::init_device_property,
+                   device_index);
+    return detail::device_properties[device_index];
+}
+
+}  // namespace kerutils


### PR DESCRIPTION
Two follow-ups to the torch::stable ABI migration:

- kerutils/device_prop.h:  align with what's already in vllm tree which is thread safe
- api/dense_decode.h:  super small nit that fixes a preexisting issue

Tested locally on GB200 (no h100 tests run) and in CI https://github.com/vllm-project/vllm/pull/48174