### PR TITLE
[Bugfix] Avoid unused sparse decode split-KV workspace

### DIFF
--- a/csrc/api/sparse_decode.h
+++ b/csrc/api/sparse_decode.h
@@ -143,8 +143,12 @@ protected:
                 }
                 cur_params.lse += start_head_idx;
                 cur_params.out += start_head_idx * params.stride_o_h_q;
-                cur_params.lse_accum += start_head_idx;
-                cur_params.o_accum += start_head_idx * params.stride_o_accum_h_q;
+                if (cur_params.lse_accum) {
+                    cur_params.lse_accum += start_head_idx;
+                }
+                if (cur_params.o_accum) {
+                    cur_params.o_accum += start_head_idx * params.stride_o_accum_h_q;
+                }
                 cur_params.h_q = 64;
                 sm100::decode::head64::run_flash_splitkv_mla_fp8_sparse_kernel<MODEL_TYPE>(cur_params);
             }
@@ -460,21 +464,28 @@ sparse_attn_decode_interface(
     params.num_splits_ptr = num_splits->mutable_data_ptr<int>();
     params.num_sm_parts = impl_meta.num_sm_parts;
 
-    // Allocate intermediate buffers for split-KV
-    const int total_num_splits = b + impl_meta.num_sm_parts;
-    lse_accum = torch::stable::new_empty(q, {total_num_splits, s_q, h_q}, ScalarType::Float);
-    o_accum = torch::stable::new_empty(q, {total_num_splits, s_q, h_q, d_v}, ScalarType::Float);
-    KU_CHECK_CONTIGUOUS(lse_accum);
-    KU_CHECK_CONTIGUOUS(o_accum);
-    params.lse_accum = lse_accum.mutable_data_ptr<float>();
-    params.o_accum = o_accum.mutable_data_ptr<float>();
-    params.stride_lse_accum_split = int64_stride_to_int(lse_accum.stride(0));
-    params.stride_lse_accum_s_q = int64_stride_to_int(lse_accum.stride(1));
-    params.stride_o_accum_split = int64_stride_to_int(o_accum.stride(0));
-    params.stride_o_accum_s_q = int64_stride_to_int(o_accum.stride(1));
-    params.stride_o_accum_h_q = int64_stride_to_int(o_accum.stride(2));
+    const bool needs_split_workspace = impl_meta.num_sm_parts > 1;
+    if (needs_split_workspace) {
+        const int total_num_splits = b + impl_meta.num_sm_parts;
+        lse_accum = torch::stable::new_empty(q, {total_num_splits, s_q, h_q}, ScalarType::Float);
+        o_accum = torch::stable::new_empty(q, {total_num_splits, s_q, h_q, d_v}, ScalarType::Float);
+        KU_CHECK_CONTIGUOUS(lse_accum);
+        KU_CHECK_CONTIGUOUS(o_accum);
+        params.lse_accum = lse_accum.mutable_data_ptr<float>();
+        params.o_accum = o_accum.mutable_data_ptr<float>();
+        params.stride_lse_accum_split = int64_stride_to_int(lse_accum.stride(0));
+        params.stride_lse_accum_s_q = int64_stride_to_int(lse_accum.stride(1));
+        params.stride_o_accum_split = int64_stride_to_int(o_accum.stride(0));
+        params.stride_o_accum_s_q = int64_stride_to_int(o_accum.stride(1));
+        params.stride_o_accum_h_q = int64_stride_to_int(o_accum.stride(2));
+    }
 
     impl->run(params, features);
+
+    if (!needs_split_workspace) {
+        delete impl;
+        return {out, torch::stable::transpose(lse, 1, 2), tile_scheduler_metadata, num_splits};
+    }
     
     CombineParams combine_params = {
         b, s_q, h_q, d_v,

--- a/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/phase1.cuh
+++ b/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/phase1.cuh
@@ -1045,15 +1045,17 @@ void KernelTemplate<FWD_MODE, D_QK>::run(const ArgT& params) {
 
     CUtensorMap tensor_map_o_accum = {};
     if constexpr (FWD_MODE == FwdMode::DecodeWithSplitKV) {
-        tensor_map_o_accum = ku::make_tensor_map(
-            {32, H_Q, D_V/32, (unsigned long)params.s_q, (unsigned long)params.num_sm_parts + params.b},
-            ku::make_stride_helper<int>({params.stride_o_accum_h_q, 32, params.stride_o_accum_s_q, params.stride_o_accum_split}, sizeof(float)),
-            {32, H_Q/2, B_EPI_SPLITKV/32, 1, 1},
-            params.o_accum,
-            CU_TENSOR_MAP_DATA_TYPE_FLOAT32,
-            CU_TENSOR_MAP_SWIZZLE_128B,
-            CU_TENSOR_MAP_L2_PROMOTION_L2_256B
-        );
+        if (params.o_accum != nullptr) {
+            tensor_map_o_accum = ku::make_tensor_map(
+                {32, H_Q, D_V/32, (unsigned long)params.s_q, (unsigned long)params.num_sm_parts + params.b},
+                ku::make_stride_helper<int>({params.stride_o_accum_h_q, 32, params.stride_o_accum_s_q, params.stride_o_accum_split}, sizeof(float)),
+                {32, H_Q/2, B_EPI_SPLITKV/32, 1, 1},
+                params.o_accum,
+                CU_TENSOR_MAP_DATA_TYPE_FLOAT32,
+                CU_TENSOR_MAP_SWIZZLE_128B,
+                CU_TENSOR_MAP_L2_PROMOTION_L2_256B
+            );
+        }
     }
 
     TmaParams tma_params;

--- a/tests/test_flash_mla_sparse_decoding.py
+++ b/tests/test_flash_mla_sparse_decoding.py
@@ -233,6 +233,51 @@ def test_flash_mla(p: TestParam) -> Result:
     return performance_result
 
 
+@torch.inference_mode()
+def test_no_split_workspace_allocation():
+    """No-split sparse decode must not allocate split-KV accumulators.
+
+    A query length equal to the SM count uses one scheduler partition. The
+    kernel writes directly to the output in this case, so allocating split-KV
+    scratch only increases peak memory and can cause runtime OOMs.
+    """
+    num_sms = torch.cuda.get_device_properties(0).multi_processor_count
+    p = RawTestParam(
+        b=1,
+        h_q=64,
+        s_q=num_sms,
+        h_kv=1,
+        s_kv=512,
+        is_varlen=False,
+        topk=64,
+        d_qk=576,
+        check_correctness=False,
+        num_runs=0,
+        seed=1,
+    ).to_test_param()
+    t = lib.generate_testcase_for_decode(p)
+    tile_scheduler_metadata, _ = flash_mla.get_mla_metadata()
+
+    def run_decode():
+        return lib.run_flash_mla_decode(p, t, tile_scheduler_metadata, None)
+
+    out, lse = run_decode()
+    torch.cuda.synchronize()
+    del out, lse
+    torch.cuda.empty_cache()
+
+    memory_before = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    out, lse = run_decode()
+    torch.cuda.synchronize()
+    peak_memory = torch.cuda.max_memory_allocated() - memory_before
+    output_memory = out.nbytes + lse.nbytes
+    assert peak_memory <= output_memory + 1024**2, (
+        f"No-split decode allocated {peak_memory / 1024**2:.2f} MiB for "
+        f"{output_memory / 1024**2:.2f} MiB of outputs"
+    )
+
+
 def main():
     dtype = torch.bfloat16
     device = torch.device("cuda:0")
@@ -241,6 +286,8 @@ def main():
     torch.cuda.set_device(device)
     torch.set_float32_matmul_precision('high')
     torch.set_num_threads(32)
+
+    test_no_split_workspace_allocation()
 
     raw_testcases = gen_testcase()
     testcases = [t.to_test_param() for t in raw_testcases]


### PR DESCRIPTION
## Summary

- avoid allocating FP32 split-KV accumulators when sparse decode has only one SM partition
- return the kernel output directly instead of launching the unnecessary combine kernel
- make the optional accumulator handling safe for the SM100 head64x2/head128 paths
- add a peak-allocation regression test

Companion vLLM integration PR: [vllm-project/vllm#53755](https://github.com/vllm-project/vllm/pull/53755).

## AI assistance

OpenAI Codex assisted with analysis, implementation, and validation. This PR is intentionally draft pending the human submitter's line-by-line review; the submitter will own and defend the change before marking it ready.
